### PR TITLE
refactor: realiza alteração do título do TCC

### DIFF
--- a/configuracao.yaml
+++ b/configuracao.yaml
@@ -4,7 +4,7 @@
 #===============================================#
 instituicao: Instituto Federal de Sergipe
 author: Reinan Gabriel Dos Santos Souza
-title: Desenvolvimento e avaliação de um sistema de E-Learning para o ensino de linguagens de programação
+title: O uso e avaliação de um sistema de e-learning no ensino de linguagens de programação
 local: Lagarto - SE
 date: '2022'
 titulacao: Bacharel


### PR DESCRIPTION
O tema geral teve que ser alterado para um tema onde houvesse a flexibilidade de poder utilizar soluções já existentes.

@close #2